### PR TITLE
move todate

### DIFF
--- a/packages/zensroom/lib/components/bookings/BookingsNewForm.js
+++ b/packages/zensroom/lib/components/bookings/BookingsNewForm.js
@@ -42,7 +42,10 @@ class BookingsNewForm extends Component {
   }
 
   updateFromDate(date) {
-    this.setState({ from: date });
+    this.setState({
+      from: date,
+      to: date.clone().add('days', 1)
+    });
   }
 
   updateToDate(date) {

--- a/packages/zensroom/lib/components/bookings/BookingsNewForm.js
+++ b/packages/zensroom/lib/components/bookings/BookingsNewForm.js
@@ -42,10 +42,12 @@ class BookingsNewForm extends Component {
   }
 
   updateFromDate(date) {
-    this.setState({
-      from: date,
-      to: date.clone().add('days', 1)
-    });
+    this.setState({ from: date });
+    if (date > this.state.to) {
+      this.setState({
+        to: date.clone().add('days', 1)
+      })
+    }
   }
 
   updateToDate(date) {


### PR DESCRIPTION
- date to and from bug fix

description: 
When the user selects a `from` date, the `to` date should be updated so that the user will not manually click through to the right month.